### PR TITLE
Case sensitive issue

### DIFF
--- a/lib/Accessible/AutoMethodsTrait.php
+++ b/lib/Accessible/AutoMethodsTrait.php
@@ -116,7 +116,7 @@ trait AutoMethodsTrait
      */
     private function getMethodCallInfo($name)
     {
-        $extractedMethod = preg_match("/^(set|get|is|add|remove)([A-Z].*)/", $name, $pregMatches);
+        $extractedMethod = preg_match("/^(set|get|is|add|remove)([A-Za-z].*)/", $name, $pregMatches);
         if ($extractedMethod) {
             $method = $pregMatches[1];
             $property = lcfirst($pregMatches[2]);


### PR DESCRIPTION
Hello,

In some situations, third-party libs are calling the __call function without camelcasing the name : `getvalue` instead of `getValue` for example.
It's the case of the `ClosureExpressionVisitor` from `doctrine/collections`.

I thought that was a bad behaviour from doctrine/collections, but after some research it seems that PHP is case unsensitive by default : https://stackoverflow.com/questions/2749781/why-are-functions-and-methods-in-php-case-insensitive

I think that this regex must matchs the default PHP behaviour and accepts lowercase getters/setters.

But, this change may be lead to a breaking change for anyone having a variable starting with "get...".
Maybe we have to make this configurable ?